### PR TITLE
fix: avoid crash

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -13,6 +13,13 @@
       ],
       "cflags_c": [
         "-std=c99",
+        "-fexceptions"
+      ],
+      "defines": [
+        "TREE_SITTER_MARKDOWN_AVOID_CRASH"
+      ],
+      "conditions": [
+        ["OS=='mac'", { "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES" } }]
       ]
     }
   ]

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -29,6 +29,7 @@ fn main() {
     cpp_config.cpp(true);
     cpp_config.include(&src_dir);
     cpp_config
+        .define("TREE_SITTER_MARKDOWN_AVOID_CRASH", None)
         .flag_if_supported("-Wno-unused-parameter")
         .flag_if_supported("-Wno-unused-but-set-variable");
     let scanner_path = src_dir.join("scanner.cc");

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -48,5 +48,6 @@ mod tests {
         parser
             .set_language(super::language())
             .expect("Error loading markdown language");
+        assert_eq!(format!("{:?}", parser.parse("abc", None).unwrap()), "{Tree {Node document (0, 0) - (0, 3)}}")
     }
 }

--- a/src/tree_sitter_markdown/block_context.cc
+++ b/src/tree_sitter_markdown/block_context.cc
@@ -6,7 +6,7 @@ bool BlockContext::has_fst_ctn() const { return has_fst_ctn_; }
 Symbol BlockContext::sym() const { return sym_; }
 LexedLength BlockContext::len() const { return len_; }
 LexedColumn BlockContext::ind() const { return ind_; }
-ParseState BlockContext::pst() const { assert(pst_ != PST_INVALID); return pst_; }
+ParseState BlockContext::pst() const { TREE_SITTER_MARKDOWN_ASSERT(pst_ != PST_INVALID); return pst_; }
 
 void BlockContext::mrk_has_fst_ctn() { has_fst_ctn_ = true; }
 
@@ -14,10 +14,10 @@ BlockContext::BlockContext(): has_fst_ctn_(false), sym_(SYM_TXT), len_(LEXED_LEN
 BlockContext::BlockContext(const Symbol sym, const LexedLength len, const LexedColumn ind): has_fst_ctn_(false), sym_(sym), len_(len), ind_(ind), pst_(blk_sym_pst(sym)) {}
 
 unsigned BlockContext::serialize(unsigned char *buffer) const {
-  assert(is_blk_sym(sym_));
-  assert(sym_ <= 0b1111111);
-  assert(len_ <= 0b11111111);
-  assert(ind_ <= 0b11111111);
+  TREE_SITTER_MARKDOWN_ASSERT(is_blk_sym(sym_));
+  TREE_SITTER_MARKDOWN_ASSERT(sym_ <= 0b1111111);
+  TREE_SITTER_MARKDOWN_ASSERT(len_ <= 0b11111111);
+  TREE_SITTER_MARKDOWN_ASSERT(ind_ <= 0b11111111);
   buffer[0] = (sym_ << 1) | has_fst_ctn_;
   buffer[1] = len_;
   buffer[2] = ind_;
@@ -75,7 +75,7 @@ void BlockContextStack::push(const BlockContext &ctx) {
   stk_.push_back(ctx);
 }
 void BlockContextStack::pop() {
-  assert(!empty());
+  TREE_SITTER_MARKDOWN_ASSERT(!empty());
   stk_.pop_back();
 }
 

--- a/src/tree_sitter_markdown/block_delimiter.cc
+++ b/src/tree_sitter_markdown/block_delimiter.cc
@@ -8,8 +8,8 @@ Symbol BlockDelimiter::sym() const { return sym_; }
 LexedLength BlockDelimiter::len() const { return len_; }
 LexedColumn BlockDelimiter::ind() const { return ind_; }
 bool BlockDelimiter::has_pos() const { return has_pos_; }
-const LexedPosition &BlockDelimiter::pos() const { assert(has_pos_); return pos_; }
-const LexedPosition &BlockDelimiter::end_pos() const { assert(has_pos_); return end_pos_; }
+const LexedPosition &BlockDelimiter::pos() const { TREE_SITTER_MARKDOWN_ASSERT(has_pos_); return pos_; }
+const LexedPosition &BlockDelimiter::end_pos() const { TREE_SITTER_MARKDOWN_ASSERT(has_pos_); return end_pos_; }
 
 void BlockDelimiter::set_len(const LexedLength len) {
   len_ = len;
@@ -21,7 +21,7 @@ void BlockDelimiter::set_pos(const LexedPosition &pos, const LexedPosition &end_
   pos_.set(pos);
   end_pos_.set(end_pos);
   has_pos_ = true;
-  assert(pos_.dist(end_pos_) == len_);
+  TREE_SITTER_MARKDOWN_ASSERT(pos_.dist(end_pos_) == len_);
 }
 void BlockDelimiter::drop_pos() {
   has_pos_ = false;
@@ -34,10 +34,10 @@ BlockDelimiter::BlockDelimiter(const Symbol sym, const LexedPosition &pos, const
   sym_(sym), len_(pos.dist(end_pos)), ind_(ind), has_pos_(true), pos_(pos), end_pos_(end_pos) {}
 
 unsigned BlockDelimiter::serialize(unsigned char *buffer) const {
-  assert(is_blk_sym(sym_));
-  assert(sym_ < 0b11111111);
-  assert(len_ < 0b11111111);
-  assert(ind_ < 0b11111111);
+  TREE_SITTER_MARKDOWN_ASSERT(is_blk_sym(sym_));
+  TREE_SITTER_MARKDOWN_ASSERT(sym_ < 0b11111111);
+  TREE_SITTER_MARKDOWN_ASSERT(len_ < 0b11111111);
+  TREE_SITTER_MARKDOWN_ASSERT(ind_ < 0b11111111);
   buffer[0] = sym_;
   buffer[1] = len_;
   buffer[2] = ind_;

--- a/src/tree_sitter_markdown/block_scan.cc
+++ b/src/tree_sitter_markdown/block_scan.cc
@@ -78,13 +78,13 @@ void scn_blk(Lexer &lxr, BlockDelimiterList &blk_dlms, const BlockContextStack &
 
     if (!is_tbl) tmp_blk_dlms.push_back(BlockDelimiter(SYM_PGH_BGN_MKR, 0));
   }
-  assert(!tmp_blk_dlms.empty());
+  TREE_SITTER_MARKDOWN_ASSERT(!tmp_blk_dlms.empty());
   push_lst_nod_mkr_if_necessary(blk_dlms, tmp_blk_dlms.front(), ind, blk_ctx_stk.empty() ? SYM_NOT_FOUND : blk_ctx_stk.back().sym());
   tmp_blk_dlms.transfer_to(blk_dlms);
 }
 
 bool /*is_interrupted*/ scn_eol(Lexer &lxr, BlockDelimiterList &blk_dlms, BlockContextStack &blk_ctx_stk) {
-  assert(is_eol_chr(lxr.lka_chr()));
+  TREE_SITTER_MARKDOWN_ASSERT(is_eol_chr(lxr.lka_chr()));
 
   LexedPosition bgn_pos = lxr.cur_pos();
 
@@ -153,7 +153,7 @@ bool /*is_interrupted*/ scn_eol(Lexer &lxr, BlockDelimiterList &blk_dlms, BlockC
       && !blk_ctx_stk.empty()
       && (blk_ctx_stk.back().sym() == SYM_BTK_FEN_COD_BGN || blk_ctx_stk.back().sym() == SYM_TLD_FEN_COD_BGN)
     ) {
-      assert(!has_blk_lbk);
+      TREE_SITTER_MARKDOWN_ASSERT(!has_blk_lbk);
       has_end_mkr = true;
       tmp_blk_dlms.push_back(BlockDelimiter(get_blk_cls_sym(blk_ctx_stk.back().sym()), 0));
       break;
@@ -168,7 +168,7 @@ bool /*is_interrupted*/ scn_eol(Lexer &lxr, BlockDelimiterList &blk_dlms, BlockC
     const bool is_eol = is_eol_chr(lxr.lka_chr());
     if (is_pas_all_blk_ctx && is_eol) {
       if (blk_ctx_stk.empty() || blk_ctx_stk.back().sym() == SYM_BQT_BGN) {
-        assert(!has_blk_lbk);
+        TREE_SITTER_MARKDOWN_ASSERT(!has_blk_lbk);
         has_blk_lbk = true;
         tmp_blk_dlms.push_back(BlockDelimiter(SYM_BNK_LBK, bgn_pos, lst_non_wsp_end_pos));
         break;
@@ -180,7 +180,7 @@ bool /*is_interrupted*/ scn_eol(Lexer &lxr, BlockDelimiterList &blk_dlms, BlockC
         || blk_ctx_stk.back().sym() == SYM_TBL_DLM_ROW_BGN_MKR
         || blk_ctx_stk.back().sym() == SYM_TBL_DAT_ROW_BGN_MKR
       ) {
-        assert(!has_blk_lbk);
+        TREE_SITTER_MARKDOWN_ASSERT(!has_blk_lbk);
         has_end_mkr = true;
         tmp_blk_dlms.push_back(BlockDelimiter(get_blk_cls_sym(blk_ctx_stk.back().sym()), 0));
         break;
@@ -203,7 +203,7 @@ bool /*is_interrupted*/ scn_eol(Lexer &lxr, BlockDelimiterList &blk_dlms, BlockC
       }
     } else if (is_pas_all_blk_ctx) {
       if (blk_ctx_stk.empty() || blk_ctx_stk.back().sym() == SYM_BQT_BGN) {
-        assert(!has_blk_lbk);
+        TREE_SITTER_MARKDOWN_ASSERT(!has_blk_lbk);
         tmp_blk_dlms.push_back(BlockDelimiter(SYM_LIT_LBK, bgn_pos, lst_non_wsp_end_pos));
         has_opn_mkr = true;
         scn_blk(lxr, tmp_blk_dlms, blk_ctx_stk, cur_ind);
@@ -216,7 +216,7 @@ bool /*is_interrupted*/ scn_eol(Lexer &lxr, BlockDelimiterList &blk_dlms, BlockC
         break;
       }
       if (blk_ctx_stk.back().sym() == SYM_HTM_BLK_DIV_BGN_MKR || blk_ctx_stk.back().sym() == SYM_HTM_BLK_CMP_BGN_MKR) {
-        assert(!has_blk_lbk);
+        TREE_SITTER_MARKDOWN_ASSERT(!has_blk_lbk);
         LexedLength ind_chr_cnt;
         LexedLength vrt_spc_cnt = lxr.clc_vtr_spc_cnt(cur_ind, 0, ind_chr_cnt);
         tmp_blk_dlms.push_back(BlockDelimiter(SYM_LIT_LBK, bgn_pos.dist(lst_non_wsp_end_pos) + ind_chr_cnt));
@@ -311,7 +311,7 @@ bool /*is_interrupted*/ scn_eol(Lexer &lxr, BlockDelimiterList &blk_dlms, BlockC
         }
         break;
       }
-      assert(
+      TREE_SITTER_MARKDOWN_ASSERT(
         !has_blk_lbk
         && (blk_ctx_stk.back().sym() == SYM_PGH_BGN_MKR
           || blk_ctx_stk.back().sym() == SYM_TBL_DLM_ROW_BGN_MKR
@@ -335,7 +335,7 @@ bool /*is_interrupted*/ scn_eol(Lexer &lxr, BlockDelimiterList &blk_dlms, BlockC
       }
       break;
     } else if (is_eol) {
-      assert(!blk_ctx_stk.empty());
+      TREE_SITTER_MARKDOWN_ASSERT(!blk_ctx_stk.empty());
       const BlockContext *fst_bqt_ctx = NULL_PTR;
       for (
         BlockContextStack::ConstIterator cur_ctx_itr = fst_failed_ctx_itr;
@@ -367,7 +367,7 @@ bool /*is_interrupted*/ scn_eol(Lexer &lxr, BlockDelimiterList &blk_dlms, BlockC
         || blk_ctx_stk.back().sym() == SYM_TBL_DLM_ROW_BGN_MKR
         || blk_ctx_stk.back().sym() == SYM_TBL_DAT_ROW_BGN_MKR
       ) {
-        assert(!has_blk_lbk);
+        TREE_SITTER_MARKDOWN_ASSERT(!has_blk_lbk);
         has_end_mkr = true;
         tmp_blk_dlms.push_back(BlockDelimiter(get_blk_cls_sym(blk_ctx_stk.back().sym()), 0));
         break;
@@ -378,9 +378,9 @@ bool /*is_interrupted*/ scn_eol(Lexer &lxr, BlockDelimiterList &blk_dlms, BlockC
         break;
       }
     } else {
-      assert(!blk_ctx_stk.empty());
+      TREE_SITTER_MARKDOWN_ASSERT(!blk_ctx_stk.empty());
       if (blk_ctx_stk.back().sym() == SYM_BTK_FEN_COD_BGN || blk_ctx_stk.back().sym() == SYM_TLD_FEN_COD_BGN) {
-        assert(!has_blk_lbk);
+        TREE_SITTER_MARKDOWN_ASSERT(!has_blk_lbk);
         has_end_mkr = true;
         tmp_blk_dlms.push_back(BlockDelimiter(get_blk_cls_sym(blk_ctx_stk.back().sym()), 0));
         break;
@@ -413,7 +413,7 @@ bool /*is_interrupted*/ scn_eol(Lexer &lxr, BlockDelimiterList &blk_dlms, BlockC
         }
         break;
       }
-      assert(blk_ctx_stk.back().sym() == SYM_PGH_BGN_MKR && !has_blk_lbk);
+      TREE_SITTER_MARKDOWN_ASSERT(blk_ctx_stk.back().sym() == SYM_PGH_BGN_MKR && !has_blk_lbk);
       if (BSR_ACCEPT == scn_blk_nod(lxr, tmp_blk_dlms, cur_ind, is_pas_all_blk_ctx, /*is_pgh_cont_ln*/ true)) {
         has_opn_mkr = true;
         BlockContextStack::ConstReverseIterator cur_ctx_itr = blk_ctx_stk.rbegin();
@@ -457,7 +457,7 @@ bool /*is_interrupted*/ scn_eol(Lexer &lxr, BlockDelimiterList &blk_dlms, BlockC
       continue;
     }
 
-    assert(is_eof_chr(lxr.lka_chr()) && !has_opn_mkr && !has_end_mkr);
+    TREE_SITTER_MARKDOWN_ASSERT(is_eof_chr(lxr.lka_chr()) && !has_opn_mkr && !has_end_mkr);
     has_blk_lbk = false;
     tmp_blk_dlms.clear();
     for (
@@ -471,7 +471,7 @@ bool /*is_interrupted*/ scn_eol(Lexer &lxr, BlockDelimiterList &blk_dlms, BlockC
   if (!has_opn_mkr && !has_end_mkr && !blk_ctx_stk.empty() && !is_eof_chr(lbk_nxt_chr)) {
     BlockContext &ctx = blk_ctx_stk.back();
     if (!ctx.has_fst_ctn() && (ctx.sym() == SYM_BTK_FEN_COD_BGN || ctx.sym() == SYM_TLD_FEN_COD_BGN)) {
-      assert(tmp_blk_dlms.front().sym() == SYM_LIT_LBK || tmp_blk_dlms.front().sym() == SYM_BNK_LBK);
+      TREE_SITTER_MARKDOWN_ASSERT(tmp_blk_dlms.front().sym() == SYM_LIT_LBK || tmp_blk_dlms.front().sym() == SYM_BNK_LBK);
       tmp_blk_dlms.transfer_to(blk_dlms, 1);
       blk_dlms.push_back(BlockDelimiter(SYM_FEN_COD_CTN_BGN_MKR, 0));
     }

--- a/src/tree_sitter_markdown/inline_context.cc
+++ b/src/tree_sitter_markdown/inline_context.cc
@@ -3,7 +3,7 @@
 namespace tree_sitter_markdown {
 
 InlineDelimiterList::Iterator InlineContext::dlm_itr() const { return dlm_itr_; }
-ParseState InlineContext::pst() const { assert(is_vld_pst()); return pst_; }
+ParseState InlineContext::pst() const { TREE_SITTER_MARKDOWN_ASSERT(is_vld_pst()); return pst_; }
 bool InlineContext::is_vld_pst() const { return pst_ != PST_INVALID; }
 bool InlineContext::has_asr() const { return has_asr_; }
 bool InlineContext::has_usc() const { return has_usc_; }
@@ -42,7 +42,7 @@ const InlineContext &InlineContextStack::back() const { return stk_.back(); }
 const InlineContext &InlineContextStack::back(const uint8_t offset) const {
   ConstReverseIterator itr = stk_.rbegin();
   for (uint8_t i = 0; i < offset; i++) itr++;
-  assert(itr != stk_.rend());
+  TREE_SITTER_MARKDOWN_ASSERT(itr != stk_.rend());
   return *itr;
 }
 
@@ -56,21 +56,21 @@ void InlineContextStack::push(const InlineDelimiterList::Iterator dlm_itr) {
   }
 }
 void InlineContextStack::pop() {
-  assert(!empty());
+  TREE_SITTER_MARKDOWN_ASSERT(!empty());
   stk_.pop_back();
 }
 void InlineContextStack::pop_erase(InlineDelimiterList &inl_dlms) {
-  assert(!empty());
+  TREE_SITTER_MARKDOWN_ASSERT(!empty());
   inl_dlms.erase(stk_.back().dlm_itr());
   stk_.pop_back();
 }
 void InlineContextStack::pop_yes() {
-  assert(!stk_.back().dlm_itr()->yes());
+  TREE_SITTER_MARKDOWN_ASSERT(!stk_.back().dlm_itr()->yes());
   stk_.back().dlm_itr()->set_yes(true);
   pop();
 }
 void InlineContextStack::pop_paired(InlineDelimiter *const end_dlm) {
-  assert(!stk_.back().dlm_itr()->has_end_dlm());
+  TREE_SITTER_MARKDOWN_ASSERT(!stk_.back().dlm_itr()->has_end_dlm());
   end_dlm->set_yes(true);
   stk_.back().dlm_itr()->set_end_dlm(end_dlm);
   pop_yes();

--- a/src/tree_sitter_markdown/inline_delimiter.cc
+++ b/src/tree_sitter_markdown/inline_delimiter.cc
@@ -13,9 +13,9 @@ MinimizedInlineDelimiter::MinimizedInlineDelimiter(): yes_(false), sym_(SYM_NOT_
 MinimizedInlineDelimiter::MinimizedInlineDelimiter(const bool yes, const Symbol sym, const LexedIndex len): yes_(yes), sym_(sym), len_(len) {}
 
 unsigned MinimizedInlineDelimiter::serialize(unsigned char *buffer) const {
-  assert(is_inl_sym(sym_));
-  assert(sym_ <= 0b1111111);
-  assert(len_ <= MAX_INL_DLM_LEN);
+  TREE_SITTER_MARKDOWN_ASSERT(is_inl_sym(sym_));
+  TREE_SITTER_MARKDOWN_ASSERT(sym_ <= 0b1111111);
+  TREE_SITTER_MARKDOWN_ASSERT(len_ <= MAX_INL_DLM_LEN);
   buffer[0] = (sym_ << 1) | yes_;
   buffer[1] = len_;
   return 2;
@@ -237,7 +237,7 @@ void InlineDelimiterList::transfer_to(MinimizedInlineDelimiterList &minimized_li
       minimized_list.push_back(inl_dlm);
     } else {
       // split SYM_EXT_AUT_LNK_BGN/SYM_EXT_AUT_LNK_CTN into multiple parts to bypass length limit for inline delimeters
-      assert(inl_dlm.sym() == SYM_EXT_AUT_LNK_BGN || inl_dlm.sym() == SYM_EXT_AUT_LNK_CTN);
+      TREE_SITTER_MARKDOWN_ASSERT(inl_dlm.sym() == SYM_EXT_AUT_LNK_BGN || inl_dlm.sym() == SYM_EXT_AUT_LNK_CTN);
       minimized_list.push_back(MinimizedInlineDelimiter(inl_dlm.yes(), inl_dlm.sym(), MAX_INL_DLM_LEN));
       LexedLength rst_len = inl_dlm.len() - MAX_INL_DLM_LEN;
       while (rst_len > 0) {

--- a/src/tree_sitter_markdown/inline_scan.cc
+++ b/src/tree_sitter_markdown/inline_scan.cc
@@ -30,7 +30,7 @@ void scn_mid(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &inl_
 }
 
 Symbol scn_inl(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &inl_ctx_stk, BlockDelimiterList &blk_dlms, BlockContextStack &blk_ctx_stk) {
-  assert(!is_wht_chr(lxr.lka_chr()));
+  TREE_SITTER_MARKDOWN_ASSERT(!is_wht_chr(lxr.lka_chr()));
   if (scn_blk_txt(lxr, inl_dlms, inl_ctx_stk, blk_dlms, blk_ctx_stk)) return SYM_BLK_TXT;
   InlineDelimiterList::Iterator nxt_inl_dlm_itr = inl_dlms.end();
   InlineDelimiterList::Iterator end_inl_dlm_itr = inl_dlms.end();
@@ -82,7 +82,7 @@ Symbol scn_inl(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &in
       || hdl_htm_atr_uqt_bgn_mkr(lxr, inl_dlms, inl_ctx_stk, nxt_inl_dlm_itr)
       || hdl_htm_atr_uqt_end_mkr(lxr, inl_dlms, inl_ctx_stk, nxt_inl_dlm_itr)
     ) {
-      assert(!is_txt);
+      TREE_SITTER_MARKDOWN_ASSERT(!is_txt);
       continue;
     }
 
@@ -208,7 +208,7 @@ bool scn_blk_txt(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
     }
     lxr.mrk_end();
     if (has_end) {
-      assert(blk_dlms.empty());
+      TREE_SITTER_MARKDOWN_ASSERT(blk_dlms.empty());
       blk_dlms.push_back(BlockDelimiter(SYM_HTM_BLK_SCR_END_MKR, lxr.cur_pos(), lxr.cur_pos()));
     }
     return true;
@@ -232,7 +232,7 @@ bool scn_blk_txt(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
     }
     lxr.mrk_end();
     if (has_end) {
-      assert(blk_dlms.empty());
+      TREE_SITTER_MARKDOWN_ASSERT(blk_dlms.empty());
       blk_dlms.push_back(BlockDelimiter(SYM_HTM_BLK_CMT_END_MKR, lxr.cur_pos(), lxr.cur_pos()));
     }
     return true;
@@ -253,7 +253,7 @@ bool scn_blk_txt(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
     }
     lxr.mrk_end();
     if (has_end) {
-      assert(blk_dlms.empty());
+      TREE_SITTER_MARKDOWN_ASSERT(blk_dlms.empty());
       blk_dlms.push_back(BlockDelimiter(SYM_HTM_BLK_PRC_END_MKR, lxr.cur_pos(), lxr.cur_pos()));
     }
     return true;
@@ -274,7 +274,7 @@ bool scn_blk_txt(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
     }
     lxr.mrk_end();
     if (has_end) {
-      assert(blk_dlms.empty());
+      TREE_SITTER_MARKDOWN_ASSERT(blk_dlms.empty());
       blk_dlms.push_back(BlockDelimiter(SYM_HTM_BLK_DCL_END_MKR, lxr.cur_pos(), lxr.cur_pos()));
     }
     return true;
@@ -297,13 +297,13 @@ bool scn_blk_txt(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
     }
     lxr.mrk_end();
     if (has_end) {
-      assert(blk_dlms.empty());
+      TREE_SITTER_MARKDOWN_ASSERT(blk_dlms.empty());
       blk_dlms.push_back(BlockDelimiter(SYM_HTM_BLK_CDA_END_MKR, lxr.cur_pos(), lxr.cur_pos()));
     }
     return true;
   }
 
-  assert(false);
+  TREE_SITTER_MARKDOWN_ASSERT(false);
 }
 
 struct ExtendedAutolinkDomainSegment {
@@ -496,7 +496,7 @@ bool scn_ext_aut_lnk(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextSta
     if (has_usc) lxr.jmp_pos(fst_usc_pos);
     LexedPosition end_pos = lxr.cur_pos();
     if (bgn_pos.dist(end_pos) == 0) {
-      assert(has_usc);
+      TREE_SITTER_MARKDOWN_ASSERT(has_usc);
       return false;
     }
     inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(false, SYM_EXT_AUT_LNK_BGN, bgn_pos, end_pos));
@@ -586,7 +586,7 @@ bool scn_inl_bsl(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
           inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(false, SYM_BSL_LBK, bgn_pos, bsl_end_pos));
           end_idx = bgn_pos.idx();
         } else {
-          assert(blk_dlms.back().sym() == SYM_LIT_LBK);
+          TREE_SITTER_MARKDOWN_ASSERT(blk_dlms.back().sym() == SYM_LIT_LBK);
           inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(true, SYM_BSL_LBK, bgn_pos, bsl_end_pos));
           lxr.jmp_pos(blk_dlms.back().end_pos());
         }
@@ -631,7 +631,7 @@ bool scn_inl_bsl(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
         inl_ctx_stk.push(
           inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(false, SYM_EML_AUT_LNK_IVD_MKR, bgn_pos, bgn_pos))
         );
-        assert(!inl_ctx_stk.back().is_vld_pst());
+        TREE_SITTER_MARKDOWN_ASSERT(!inl_ctx_stk.back().is_vld_pst());
       } else {
         inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(false, SYM_BSL_ESC, bgn_pos, lxr.cur_pos()));
       }
@@ -651,7 +651,7 @@ bool scn_inl_btk(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
       inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(false, SYM_COD_SPN_BGN, bgn_pos, end_pos))
     );
   } else {
-    assert(!inl_ctx_stk.empty());
+    TREE_SITTER_MARKDOWN_ASSERT(!inl_ctx_stk.empty());
     if (inl_ctx_stk.back().btk_len() == btk_len) {
       inl_ctx_stk.pop_paired(
         inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(true, SYM_COD_SPN_END, bgn_pos, end_pos))
@@ -667,7 +667,7 @@ bool scn_inl_cln(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
   if (lxr.lka_chr() != ':') return false;
   if (VLD(SYM_LNK_REF_DEF_CLN)) {
     InlineDelimiterList::Iterator lnk_end_itr = inl_ctx_stk.back().dlm_itr();
-    assert(lnk_end_itr->sym() == SYM_LNK_END);
+    TREE_SITTER_MARKDOWN_ASSERT(lnk_end_itr->sym() == SYM_LNK_END);
 
     InlineDelimiterList::Iterator lnk_bgn_itr = inl_ctx_stk.back(1).dlm_itr();
     if (lnk_bgn_itr->sym() != SYM_LNK_BGN) return false;
@@ -710,7 +710,7 @@ bool scn_inl_eql(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
   LexedPosition bgn_pos = lxr.cur_pos();
   lxr.adv();
   LexedPosition end_pos = lxr.cur_pos();
-  assert(inl_ctx_stk.back().dlm_itr()->sym() == SYM_HTM_ATR_KEY_END_MKR);
+  TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == SYM_HTM_ATR_KEY_END_MKR);
   inl_ctx_stk.pop_erase(inl_dlms);
   inl_ctx_stk.push(
     inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(false, SYM_HTM_ATR_EQL, bgn_pos, end_pos))
@@ -736,7 +736,7 @@ bool scn_inl_hyp(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
     LexedLength hyp_len = lxr.adv_rpt_len('-', 3);
     lxr.adv_rpt('-');
     if (hyp_len == 2 && lxr.adv_if('>')) {
-      assert(inl_ctx_stk.back().dlm_itr()->sym() == SYM_HTM_CMT_BGN);
+      TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == SYM_HTM_CMT_BGN);
       inl_ctx_stk.pop_paired(
         inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(true, SYM_HTM_CMT_END, bgn_pos, lxr.cur_pos()))
       );
@@ -744,7 +744,7 @@ bool scn_inl_hyp(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
       inl_ctx_stk.push(
         inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(false, SYM_HTM_CMT_END, bgn_pos, lxr.cur_pos()))
       );
-      assert(!inl_ctx_stk.back().is_vld_pst());
+      TREE_SITTER_MARKDOWN_ASSERT(!inl_ctx_stk.back().is_vld_pst());
     } else {
       inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(false, SYM_HTM_CMT_END, bgn_pos, lxr.cur_pos()));
     }
@@ -795,7 +795,7 @@ bool scn_inl_lbt(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
     return true;
   }
   if (VLD(SYM_LNK_REF_BGN)) {
-    assert(inl_ctx_stk.back().dlm_itr()->sym() == SYM_LNK_END);
+    TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == SYM_LNK_END);
     LexedPosition bgn_pos = lxr.cur_pos();
     lxr.adv();
     inl_ctx_stk.push(
@@ -817,7 +817,7 @@ bool scn_inl_lng(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
     return true;
   }
   if (VLD(SYM_AUT_LNK_HTM_OPN_TAG_BGN)) {
-    assert(
+    TREE_SITTER_MARKDOWN_ASSERT(
       VLD(SYM_HTM_CLS_TAG_BGN)
       && VLD(SYM_HTM_DCL_BGN)
       && VLD(SYM_HTM_CMT_BGN)
@@ -885,7 +885,7 @@ bool scn_inl_lng(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
 bool scn_inl_lpr(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &inl_ctx_stk, BlockDelimiterList &blk_dlms, BlockContextStack &blk_ctx_stk, const InlineDelimiterList::Iterator &nxt_inl_dlm_itr) {
   if (lxr.lka_chr() != '(') return false;
   if (VLD(SYM_LNK_INL_BGN)) {
-    assert(inl_ctx_stk.back().dlm_itr()->sym() == SYM_LNK_END);
+    TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == SYM_LNK_END);
     LexedPosition bgn_pos = lxr.cur_pos();
     lxr.adv();
     inl_ctx_stk.push(
@@ -922,7 +922,7 @@ bool scn_inl_qus(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
   LexedPosition bgn_pos = lxr.cur_pos();
   lxr.adv();
   if (lxr.adv_if('>')) {
-    assert(inl_ctx_stk.back().dlm_itr()->sym() == SYM_HTM_PRC_BGN);
+    TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == SYM_HTM_PRC_BGN);
     inl_ctx_stk.pop_paired(
       inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(true, SYM_HTM_PRC_END, bgn_pos, lxr.cur_pos()))
     );
@@ -938,7 +938,7 @@ bool scn_inl_rbt(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
     InlineDelimiterList::Iterator ctx_dlm_itr = inl_ctx_stk.back().dlm_itr();
     bool is_img = ctx_dlm_itr->sym() == SYM_IMG_BGN;
     bool is_lnk = ctx_dlm_itr->sym() == SYM_LNK_BGN;
-    assert(is_img || is_lnk);
+    TREE_SITTER_MARKDOWN_ASSERT(is_img || is_lnk);
 
     LexedPosition bgn_pos = lxr.cur_pos();
     lxr.adv();
@@ -961,7 +961,7 @@ bool scn_inl_rbt(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
   }
   if (VLD(SYM_LNK_REF_END)) {
     InlineDelimiterList::Iterator ctx_dlm_itr = inl_ctx_stk.back().dlm_itr();
-    assert(ctx_dlm_itr->sym() == SYM_LNK_REF_BGN);
+    TREE_SITTER_MARKDOWN_ASSERT(ctx_dlm_itr->sym() == SYM_LNK_REF_BGN);
 
     LexedPosition bgn_pos = lxr.cur_pos();
     lxr.adv();
@@ -972,7 +972,7 @@ bool scn_inl_rbt(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
                    && lxr.has_chr_in_rng(is_non_wht_chr, ctx_dlm_itr->end_pos().idx() + 1, bgn_pos.idx() + 1);
 
     InlineDelimiterList::Iterator lnk_end_itr = inl_ctx_stk.back(1).dlm_itr();
-    assert(lnk_end_itr->sym() == SYM_LNK_END);
+    TREE_SITTER_MARKDOWN_ASSERT(lnk_end_itr->sym() == SYM_LNK_END);
 
     bool is_lnk_frt_vlk_lnk_lbl = lnk_end_itr->ctm_dat();
 
@@ -980,7 +980,7 @@ bool scn_inl_rbt(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
       inl_ctx_stk.push(
         inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(false, SYM_LNK_REF_END, bgn_pos, end_pos))
       );
-      assert(!inl_ctx_stk.back().is_vld_pst());
+      TREE_SITTER_MARKDOWN_ASSERT(!inl_ctx_stk.back().is_vld_pst());
     } else {
       InlineDelimiterList::Iterator lnk_ref_end_itr = inl_dlms.insert(
         nxt_inl_dlm_itr,
@@ -993,7 +993,7 @@ bool scn_inl_rbt(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
     return true;
   }
   if (VLD(SYM_HTM_CDA_END)) {
-    assert(inl_ctx_stk.back().dlm_itr()->sym() == SYM_HTM_CDA_BGN);
+    TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == SYM_HTM_CDA_BGN);
     LexedPosition bgn_pos = lxr.cur_pos();
     LexedLength rbt_len = lxr.adv_rpt_len(']');
     if (rbt_len > 2 && lxr.adv_if('>')) {
@@ -1017,9 +1017,9 @@ bool scn_inl_rbt(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
 bool scn_inl_rng(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &inl_ctx_stk, BlockDelimiterList &blk_dlms, BlockContextStack &blk_ctx_stk, const InlineDelimiterList::Iterator &nxt_inl_dlm_itr) {
   if (lxr.lka_chr() != '>') return false;
   if (VLD(SYM_LNK_DST_EXP_END)) {
-    assert(inl_ctx_stk.back().dlm_itr()->sym() == SYM_LNK_DST_EXP_BGN);
+    TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == SYM_LNK_DST_EXP_BGN);
     InlineDelimiterList::Iterator lnk_end_nxt_itr = inl_ctx_stk.back(1).dlm_itr();
-    assert(lnk_end_nxt_itr->sym() == SYM_LNK_INL_BGN || lnk_end_nxt_itr->sym() == SYM_LNK_REF_DEF_CLN);
+    TREE_SITTER_MARKDOWN_ASSERT(lnk_end_nxt_itr->sym() == SYM_LNK_INL_BGN || lnk_end_nxt_itr->sym() == SYM_LNK_REF_DEF_CLN);
     LexedPosition bgn_pos = lxr.cur_pos();
     lxr.adv();
     LexedPosition end_pos = lxr.cur_pos();
@@ -1034,7 +1034,7 @@ bool scn_inl_rng(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
       inl_ctx_stk.push(
         inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(false, SYM_LNK_DST_EXP_END, bgn_pos, end_pos))
       );
-      assert(!inl_ctx_stk.back().is_vld_pst());
+      TREE_SITTER_MARKDOWN_ASSERT(!inl_ctx_stk.back().is_vld_pst());
     }
     return true;
   }
@@ -1042,7 +1042,7 @@ bool scn_inl_rng(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
     if (inl_ctx_stk.back().dlm_itr()->sym() == SYM_EML_AUT_LNK_END_MKR) {
       inl_ctx_stk.pop_erase(inl_dlms);
     }
-    assert(
+    TREE_SITTER_MARKDOWN_ASSERT(
       inl_ctx_stk.back().dlm_itr()->sym() == SYM_URI_AUT_LNK_BGN
       || inl_ctx_stk.back().dlm_itr()->sym() == SYM_EML_AUT_LNK_BGN
     );
@@ -1059,7 +1059,7 @@ bool scn_inl_rng(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
       || inl_ctx_stk.back().dlm_itr()->sym() == SYM_HTM_CLS_TAG_NAM_END_MKR
       || inl_ctx_stk.back().dlm_itr()->sym() == SYM_HTM_DCL_NAM_END_MKR
     ) inl_ctx_stk.pop_erase(inl_dlms);
-    assert(
+    TREE_SITTER_MARKDOWN_ASSERT(
       inl_ctx_stk.back().dlm_itr()->sym() == SYM_HTM_OPN_TAG_BGN
       || inl_ctx_stk.back().dlm_itr()->sym() == SYM_HTM_CLS_TAG_BGN
       || inl_ctx_stk.back().dlm_itr()->sym() == SYM_HTM_DCL_BGN
@@ -1081,7 +1081,7 @@ bool scn_inl_rpr(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
       inl_ctx_stk.back().dlm_itr()->sym() == SYM_LNK_DST_END_MKR
       || inl_ctx_stk.back().dlm_itr()->sym() == SYM_LNK_TIT_END_MKR
     ) inl_ctx_stk.pop_erase(inl_dlms);
-    assert(inl_ctx_stk.back().dlm_itr()->sym() == SYM_LNK_INL_BGN);
+    TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == SYM_LNK_INL_BGN);
 
     LexedPosition bgn_pos = lxr.cur_pos();
     lxr.adv();
@@ -1097,7 +1097,7 @@ bool scn_inl_rpr(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
     return true;
   }
   if (VLD(SYM_LNK_DST_IMP_PRN_END)) {
-    assert(inl_ctx_stk.back().dlm_itr()->sym() == SYM_LNK_DST_IMP_PRN_BGN);
+    TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == SYM_LNK_DST_IMP_PRN_BGN);
     inl_ctx_stk.pop();
     LexedPosition bgn_pos = lxr.cur_pos();
     lxr.adv();
@@ -1115,7 +1115,7 @@ bool scn_inl_slh(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
     if (
       inl_ctx_stk.back().dlm_itr()->sym() == SYM_HTM_ATR_KEY_END_MKR
     ) inl_ctx_stk.pop_erase(inl_dlms);
-    assert(inl_ctx_stk.back().dlm_itr()->sym() == SYM_HTM_OPN_TAG_BGN);
+    TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == SYM_HTM_OPN_TAG_BGN);
     inl_ctx_stk.pop_paired(
       inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(true, SYM_HTM_SLF_TAG_END, bgn_pos, lxr.cur_pos()))
     );
@@ -1123,7 +1123,7 @@ bool scn_inl_slh(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
     inl_ctx_stk.push(
       inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(false, SYM_HTM_SLF_TAG_END, bgn_pos, lxr.cur_pos()))
     );
-    assert(!inl_ctx_stk.back().is_vld_pst());
+    TREE_SITTER_MARKDOWN_ASSERT(!inl_ctx_stk.back().is_vld_pst());
   }
   return true;
 }
@@ -1311,7 +1311,7 @@ bool scn_inl_txt(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &
         while (is_asc_ltr_chr(lxr.lka_chr()) || is_num_chr(lxr.lka_chr()) || lxr.lka_chr() == '_' || lxr.lka_chr() == '.' || lxr.lka_chr() == ':' || lxr.lka_chr() == '-') lxr.adv();
         if (ctx_sym == SYM_HTM_ATR_KEY_END_MKR) {
           inl_ctx_stk.pop_erase(inl_dlms);
-          assert(inl_ctx_stk.back().dlm_itr()->sym() == SYM_HTM_OPN_TAG_BGN);
+          TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == SYM_HTM_OPN_TAG_BGN);
         }
         inl_ctx_stk.push(
           inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(false, SYM_HTM_ATR_KEY_END_MKR, lxr.cur_pos(), lxr.cur_pos()))
@@ -1399,7 +1399,7 @@ bool scn_aut_lnk_htm_opn_tag_txt(
       || lxr.lka_chr() == '?' || lxr.lka_chr() == '^' || lxr.lka_chr() == '_' || lxr.lka_chr() == '`'
       || lxr.lka_chr() == '{' || lxr.lka_chr() == '|' || lxr.lka_chr() == '}' || lxr.lka_chr() == '~'
     ) {
-      assert(inl_ctx_stk.back().dlm_itr()->sym() == SYM_AUT_LNK_HTM_OPN_TAG_BGN);
+      TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == SYM_AUT_LNK_HTM_OPN_TAG_BGN);
       inl_ctx_stk.back().dlm_itr()->set_sym(SYM_EML_AUT_LNK_BGN);
       inl_ctx_stk.back().upd_pst();
       return true;
@@ -1407,7 +1407,7 @@ bool scn_aut_lnk_htm_opn_tag_txt(
   }
 
   if (is_htm_opn_tag && txt_len >= 1 && (is_wht_chr(lxr.lka_chr()) || lxr.lka_chr() == '>' || (lxr.cur_chr() == '/' && slh_cnt == 1 && txt_len >= 2))) {
-    assert(inl_ctx_stk.back().dlm_itr()->sym() == SYM_AUT_LNK_HTM_OPN_TAG_BGN);
+    TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == SYM_AUT_LNK_HTM_OPN_TAG_BGN);
     inl_ctx_stk.back().dlm_itr()->set_sym(SYM_HTM_OPN_TAG_BGN);
     inl_ctx_stk.back().upd_pst();
     if (lxr.cur_chr() == '/') lxr.jmp_pos(lxr.cur_pos().clone_add(-1));
@@ -1415,14 +1415,14 @@ bool scn_aut_lnk_htm_opn_tag_txt(
   }
 
   if (is_uri_aut_lnk && txt_len >= 2 && txt_len <= 32 && lxr.adv_if(':')) {
-    assert(inl_ctx_stk.back().dlm_itr()->sym() == SYM_AUT_LNK_HTM_OPN_TAG_BGN);
+    TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == SYM_AUT_LNK_HTM_OPN_TAG_BGN);
     inl_ctx_stk.back().dlm_itr()->set_sym(SYM_URI_AUT_LNK_BGN);
     inl_ctx_stk.back().upd_pst();
     return true;
   }
 
   if (is_eml_aut_lnk && txt_len >= 1) {
-    assert(inl_ctx_stk.back().dlm_itr()->sym() == SYM_AUT_LNK_HTM_OPN_TAG_BGN);
+    TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == SYM_AUT_LNK_HTM_OPN_TAG_BGN);
     inl_ctx_stk.back().dlm_itr()->set_sym(SYM_EML_AUT_LNK_BGN);
     inl_ctx_stk.back().upd_pst();
     return true;
@@ -1588,9 +1588,9 @@ bool scn_lnk_tit_end(
   Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &inl_ctx_stk, BlockDelimiterList &blk_dlms, BlockContextStack &blk_ctx_stk, const InlineDelimiterList::Iterator &nxt_inl_dlm_itr
 ) {
   if (lxr.lka_chr() != dlm_chr || !VLD(end_sym)) return false;
-  assert(inl_ctx_stk.back().dlm_itr()->sym() == bgn_sym);
+  TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == bgn_sym);
   Symbol lnk_end_nxt_sym = inl_ctx_stk.back(2).dlm_itr()->sym();
-  assert(lnk_end_nxt_sym == SYM_LNK_INL_BGN || lnk_end_nxt_sym == SYM_LNK_REF_DEF_CLN);
+  TREE_SITTER_MARKDOWN_ASSERT(lnk_end_nxt_sym == SYM_LNK_INL_BGN || lnk_end_nxt_sym == SYM_LNK_REF_DEF_CLN);
   LexedPosition bgn_pos = lxr.cur_pos();
   lxr.adv();
   LexedPosition end_pos = lxr.cur_pos();
@@ -1608,14 +1608,14 @@ bool scn_lnk_tit_end(
       inl_ctx_stk.push(
         inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(false, end_sym, bgn_pos, end_pos))
       );
-      assert(!inl_ctx_stk.back().is_vld_pst());
+      TREE_SITTER_MARKDOWN_ASSERT(!inl_ctx_stk.back().is_vld_pst());
     }
   } else {
     if (is_wht_chr(lxr.lka_chr()) || lxr.lka_chr() == ')') {
       inl_ctx_stk.pop_paired(
         inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(true, end_sym, bgn_pos, end_pos))
       );
-      assert(inl_ctx_stk.back().dlm_itr()->sym() == SYM_LNK_DST_END_MKR);
+      TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == SYM_LNK_DST_END_MKR);
       inl_ctx_stk.pop_erase(inl_dlms);
       inl_ctx_stk.push(
         inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(false, SYM_LNK_TIT_END_MKR, end_pos, end_pos))
@@ -1624,7 +1624,7 @@ bool scn_lnk_tit_end(
       inl_ctx_stk.push(
         inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(false, end_sym, bgn_pos, end_pos))
       );
-      assert(!inl_ctx_stk.back().is_vld_pst());
+      TREE_SITTER_MARKDOWN_ASSERT(!inl_ctx_stk.back().is_vld_pst());
     }
   }
   return true;
@@ -1635,7 +1635,7 @@ bool scn_htm_atr_val_bgn(
   Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &inl_ctx_stk, BlockDelimiterList &blk_dlms, BlockContextStack &blk_ctx_stk, const InlineDelimiterList::Iterator &nxt_inl_dlm_itr
 ) {
   if (lxr.lka_chr() != dlm_chr || !VLD(bgn_sym)) return false;
-  assert(inl_ctx_stk.back().dlm_itr()->sym() == SYM_HTM_ATR_EQL);
+  TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == SYM_HTM_ATR_EQL);
   inl_ctx_stk.pop_yes();
   LexedPosition bgn_pos = lxr.cur_pos();
   lxr.adv();
@@ -1653,7 +1653,7 @@ bool scn_htm_atr_val_end(
   LexedPosition bgn_pos = lxr.cur_pos();
   lxr.adv();
   if (is_wht_chr(lxr.lka_chr()) || lxr.lka_chr() == '/' || lxr.lka_chr() == '>') {
-    assert(inl_ctx_stk.back().dlm_itr()->sym() == bgn_sym);
+    TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == bgn_sym);
     inl_ctx_stk.pop_paired(
       inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(true, end_sym, bgn_pos, lxr.cur_pos()))
     );
@@ -1661,7 +1661,7 @@ bool scn_htm_atr_val_end(
     inl_ctx_stk.push(
       inl_dlms.insert(nxt_inl_dlm_itr, InlineDelimiter(false, end_sym, bgn_pos, lxr.cur_pos()))
     );
-    assert(!inl_ctx_stk.back().is_vld_pst());
+    TREE_SITTER_MARKDOWN_ASSERT(!inl_ctx_stk.back().is_vld_pst());
   }
   return true;
 }
@@ -1715,18 +1715,18 @@ bool hdl_htm_atr_uqt_end_mkr(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineCo
 }
 
 void hdl_paired_lnk_end(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &inl_ctx_stk, BlockDelimiterList &blk_dlms, BlockContextStack &blk_ctx_stk) {
-  assert(inl_ctx_stk.back().dlm_itr()->sym() == SYM_LNK_END);
+  TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == SYM_LNK_END);
   LexedPosition ori_pos = lxr.cur_pos();
 
   InlineDelimiterList::Iterator lnk_end_itr = inl_ctx_stk.back().dlm_itr();
   inl_ctx_stk.pop();
 
-  assert(!inl_ctx_stk.empty());
+  TREE_SITTER_MARKDOWN_ASSERT(!inl_ctx_stk.empty());
 
   bool is_img = inl_ctx_stk.back().dlm_itr()->sym() == SYM_IMG_BGN;
   bool is_lnk = inl_ctx_stk.back().dlm_itr()->sym() == SYM_LNK_BGN;
 
-  assert(is_img || is_lnk);
+  TREE_SITTER_MARKDOWN_ASSERT(is_img || is_lnk);
 
   InlineDelimiterList::Iterator lnk_bgn_itr = inl_ctx_stk.back().dlm_itr();
   inl_ctx_stk.pop_paired(lnk_end_itr);
@@ -1751,18 +1751,18 @@ void hdl_paired_lnk_end(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContext
 }
 
 void hdl_paired_lnk_ref_def(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &inl_ctx_stk, BlockDelimiterList &blk_dlms, BlockContextStack &blk_ctx_stk) {
-  assert(inl_ctx_stk.back().dlm_itr()->sym() == SYM_LNK_DST_END_MKR);
+  TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == SYM_LNK_DST_END_MKR);
   inl_ctx_stk.pop_erase(inl_dlms);
-  assert(inl_ctx_stk.back().dlm_itr()->sym() == SYM_LNK_REF_DEF_CLN);
+  TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.back().dlm_itr()->sym() == SYM_LNK_REF_DEF_CLN);
   inl_ctx_stk.pop_yes();
   InlineDelimiterList::Iterator lnk_end_itr = inl_ctx_stk.back().dlm_itr();
-  assert(lnk_end_itr->sym() == SYM_LNK_END);
+  TREE_SITTER_MARKDOWN_ASSERT(lnk_end_itr->sym() == SYM_LNK_END);
   inl_ctx_stk.pop();
   InlineDelimiterList::Iterator lnk_bgn_itr = inl_ctx_stk.back().dlm_itr();
-  assert(lnk_bgn_itr->sym() == SYM_LNK_BGN);
+  TREE_SITTER_MARKDOWN_ASSERT(lnk_bgn_itr->sym() == SYM_LNK_BGN);
   lnk_bgn_itr->set_sym(SYM_LNK_REF_DEF_BGN);
   inl_ctx_stk.pop_paired(lnk_end_itr);
-  assert(inl_ctx_stk.empty());
+  TREE_SITTER_MARKDOWN_ASSERT(inl_ctx_stk.empty());
   for (InlineDelimiterList::Iterator itr = ++lnk_bgn_itr; itr != lnk_end_itr;) {
     if (itr->sym() == SYM_BSL_ESC || itr->sym() == SYM_BSL_LBK) {
       if (itr->sym() == SYM_BSL_LBK) itr->set_yes(false);
@@ -1773,7 +1773,7 @@ void hdl_paired_lnk_ref_def(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineCon
 }
 
 void hdl_unpaired_inl_dlm(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineContextStack &inl_ctx_stk, BlockDelimiterList &blk_dlms, BlockContextStack &blk_ctx_stk, InlineDelimiterList::Iterator &nxt_inl_dlm_itr, const InlineDelimiterList::Iterator &end_inl_dlm_itr) {
-  assert(!inl_ctx_stk.empty());
+  TREE_SITTER_MARKDOWN_ASSERT(!inl_ctx_stk.empty());
   InlineDelimiterList::Iterator unpaired_dlm_itr = inl_ctx_stk.back().dlm_itr();
   bool shd_ers = false;
   bool shd_hdl_lnk_end = false;
@@ -1901,7 +1901,7 @@ void hdl_unpaired_inl_dlm(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineConte
     inl_dlms.erase(NXT_ITR(unpaired_dlm_itr), end_inl_dlm_itr);
   }
   if (shd_hdl_lnk_end) {
-    assert(unpaired_dlm_itr->sym() == SYM_LNK_END);
+    TREE_SITTER_MARKDOWN_ASSERT(unpaired_dlm_itr->sym() == SYM_LNK_END);
     InlineDelimiterList::Iterator lnk_end_itr = unpaired_dlm_itr;
     bool is_vld_lnk_lbl = lnk_end_itr->ctm_dat();
     if (is_vld_lnk_lbl) {
@@ -1912,7 +1912,7 @@ void hdl_unpaired_inl_dlm(Lexer &lxr, InlineDelimiterList &inl_dlms, InlineConte
     }
     inl_ctx_stk.pop();
     unpaired_dlm_itr = inl_ctx_stk.back().dlm_itr();
-    assert(unpaired_dlm_itr->sym() == SYM_LNK_BGN || unpaired_dlm_itr->sym() == SYM_IMG_BGN);
+    TREE_SITTER_MARKDOWN_ASSERT(unpaired_dlm_itr->sym() == SYM_LNK_BGN || unpaired_dlm_itr->sym() == SYM_IMG_BGN);
   }
   switch (unpaired_dlm_itr->sym()) {
     case SYM_ASR_BGN:

--- a/src/tree_sitter_markdown/lexer.cc
+++ b/src/tree_sitter_markdown/lexer.cc
@@ -163,15 +163,15 @@ LexedLength Lexer::adv_rpt_len(bool (*is_chr)(LexedCharacter), const LexedLength
 }
 
 void Lexer::bgn_buf() {
-  assert(buf_bgn_idx_ == LEXED_INDEX_MAX);
+  TREE_SITTER_MARKDOWN_ASSERT(buf_bgn_idx_ == LEXED_INDEX_MAX);
   buf_bgn_idx_ = cur_idx_;
   chr_buf_.push_back(cur_chr_);
   chr_buf_.push_back(lka_chr_);
 }
 void Lexer::jmp_pos(const LexedPosition &pos) {
   if (pos.idx() == cur_idx_) return;
-  assert(pos.idx() >= buf_bgn_idx_);
-  assert(pos.idx() - buf_bgn_idx_ < chr_buf_.size() - 1);
+  TREE_SITTER_MARKDOWN_ASSERT(pos.idx() >= buf_bgn_idx_);
+  TREE_SITTER_MARKDOWN_ASSERT(pos.idx() - buf_bgn_idx_ < chr_buf_.size() - 1);
   cur_idx_ = pos.idx();
   cur_row_ = pos.row();
   cur_col_ = pos.col();
@@ -181,19 +181,19 @@ void Lexer::jmp_pos(const LexedPosition &pos) {
   cur_ind_ = 0;
 }
 bool Lexer::has_chr_at_idx(const LexedCharacter chr, const LexedIndex idx) const {
-  assert(idx >= buf_bgn_idx_);
-  assert(idx - buf_bgn_idx_ < chr_buf_.size());
+  TREE_SITTER_MARKDOWN_ASSERT(idx >= buf_bgn_idx_);
+  TREE_SITTER_MARKDOWN_ASSERT(idx - buf_bgn_idx_ < chr_buf_.size());
   return idx < 0 ? false : chr_buf_[idx - buf_bgn_idx_] == chr;
 }
 bool Lexer::has_chr_at_idx(bool (*is_chr)(LexedCharacter), const LexedIndex idx) const {
-  assert(idx >= buf_bgn_idx_);
-  assert(idx - buf_bgn_idx_ < chr_buf_.size());
+  TREE_SITTER_MARKDOWN_ASSERT(idx >= buf_bgn_idx_);
+  TREE_SITTER_MARKDOWN_ASSERT(idx - buf_bgn_idx_ < chr_buf_.size());
   return idx < 0 ? false : is_chr(chr_buf_[idx - buf_bgn_idx_]);
 }
 bool Lexer::has_chr_in_rng(bool (*is_chr)(LexedCharacter), const LexedIndex idx, const LexedIndex end_idx) const {
-  assert(idx >= buf_bgn_idx_);
-  assert(idx - buf_bgn_idx_ <= end_idx);
-  assert(end_idx - buf_bgn_idx_ < chr_buf_.size() - 1);
+  TREE_SITTER_MARKDOWN_ASSERT(idx >= buf_bgn_idx_);
+  TREE_SITTER_MARKDOWN_ASSERT(idx - buf_bgn_idx_ <= end_idx);
+  TREE_SITTER_MARKDOWN_ASSERT(end_idx - buf_bgn_idx_ < chr_buf_.size() - 1);
   for (LexedIndex i = idx - buf_bgn_idx_; i < end_idx - buf_bgn_idx_; i++) {
     if (is_chr(chr_buf_[i])) return true;
   }
@@ -204,7 +204,7 @@ bool Lexer::has_chr_in_rng(bool (*is_chr)(LexedCharacter), const LexedPosition p
 }
 
 void Lexer::bgn_rec_tbl_col_cnt() {
-  assert(!is_rec_tbl_col_cnt_);
+  TREE_SITTER_MARKDOWN_ASSERT(!is_rec_tbl_col_cnt_);
   is_rec_tbl_col_cnt_ = true;
   tbl_col_is_bgn_ = true;
   tbl_col_has_bgn_pip_ = false;
@@ -212,11 +212,11 @@ void Lexer::bgn_rec_tbl_col_cnt() {
   tbl_col_pip_cnt_ = 0;
 }
 void Lexer::end_rec_tbl_col_cnt() {
-  assert(is_rec_tbl_col_cnt_);
+  TREE_SITTER_MARKDOWN_ASSERT(is_rec_tbl_col_cnt_);
   is_rec_tbl_col_cnt_ = false;
 }
 uint16_t Lexer::tbl_col_cnt() {
-  assert(is_rec_tbl_col_cnt_);
+  TREE_SITTER_MARKDOWN_ASSERT(is_rec_tbl_col_cnt_);
   uint16_t tbl_col_cnt_ = tbl_col_pip_cnt_ + 1;
   if (tbl_col_has_bgn_pip_) tbl_col_cnt_--;
   bool has_end_pip = (tbl_col_pip_cnt_ - tbl_col_has_bgn_pip_) && !tbl_col_has_ctn_;
@@ -238,13 +238,13 @@ LexedLength Lexer::clc_vtr_spc_cnt(const LexedColumn cur_ind, const LexedColumn 
       return ind - actual_tgt_ind;
     }
   }
-  assert(false);
+  TREE_SITTER_MARKDOWN_ASSERT(false);
 }
 
 bool Lexer::ret_sym(const TokenType rlt_sym) {
-  assert(end_col_ != LEXED_COLUMN_MAX);
+  TREE_SITTER_MARKDOWN_ASSERT(end_col_ != LEXED_COLUMN_MAX);
   bgn_col_ = end_col_;
-  assert(end_chr_ != LEXED_CHARACTER_MAX);
+  TREE_SITTER_MARKDOWN_ASSERT(end_chr_ != LEXED_CHARACTER_MAX);
   bgn_chr_ = end_chr_;
   lxr_->result_symbol = rlt_sym;
   return true;

--- a/src/tree_sitter_markdown/parse_table.cc
+++ b/src/tree_sitter_markdown/parse_table.cc
@@ -47,7 +47,7 @@ Symbol get_blk_cls_sym(const Symbol opn_sym) {
     case SYM_TBL_HED_ROW_BGN_MKR:
     case SYM_TBL_DLM_ROW_BGN_MKR:
     case SYM_TBL_DAT_ROW_BGN_MKR: return SYM_TBL_ROW_END_MKR;
-    default: assert(false);
+    default: TREE_SITTER_MARKDOWN_ASSERT(false);
   }
 }
 

--- a/src/tree_sitter_markdown/shared_type.cc
+++ b/src/tree_sitter_markdown/shared_type.cc
@@ -17,7 +17,7 @@ LexedPosition::LexedPosition(const LexedIndex idx, const LexedRow row, const Lex
 LexedPosition LexedPosition::clone_add(const LexedIndex offset_idx) const { return LexedPosition(idx_ + offset_idx, row_, col_ + offset_idx); }
 
 LexedLength LexedPosition::dist(const LexedPosition &pos) const {
-  assert(idx_ <= pos.idx());
+  TREE_SITTER_MARKDOWN_ASSERT(idx_ <= pos.idx());
   return pos.idx() - idx_;
 }
 

--- a/src/tree_sitter_markdown/util.cc
+++ b/src/tree_sitter_markdown/util.cc
@@ -34,7 +34,7 @@ bool adv_blk_htm_end(Lexer &lxr) {
 }
 
 bool vld_sym(const Symbol sym, const BlockContextStack &blk_ctx_stk) {
-  assert(!blk_ctx_stk.empty());
+  TREE_SITTER_MARKDOWN_ASSERT(!blk_ctx_stk.empty());
   return vld_sym(sym, blk_ctx_stk.back().pst());
 }
 bool vld_sym(const Symbol sym, const BlockContextStack &blk_ctx_stk, const InlineContextStack &inl_ctx_stk) {


### PR DESCRIPTION
Fixes #24

This PR mitigates the crash issue with the cost of the parsed tree being inaccurate in the previously crashed cases, but the parsed tree should be accurate again once the typing finished if the assumption of the crash caused by unfinished typing is correct.

Since `tree-sitter-cli` hardcoded the `-fno-exceptions` flag for the `tree-sitter test` command, the "avoid crash" build is not enabled in the source code by default, but it's enabled for the node/rust binding. To enable the "avoid crash" build for a custom binding, simply define the `TREE_SITTER_MARKDOWN_AVOID_CRASH` macro with `-fexceptions` flag enabled.