### PR TITLE
fix: add cflags_cc

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -15,6 +15,9 @@
         "-std=c99",
         "-fexceptions"
       ],
+      "cflags_cc": [
+        "-fexceptions"
+      ],
       "defines": [
         "TREE_SITTER_MARKDOWN_AVOID_CRASH"
       ],


### PR DESCRIPTION
_npm install_ fails on my system

```
Linux 5.12.15-arch1-1
node v14.16.0
npm  v7.17.0
node-gyp -v v8.1.0
```


<details>
<summary>See the error</summary>

```
131 verbose Linux 5.12.15-arch1-1
132 verbose argv "/usr/bin/node" "/usr/bin/npm" "i"
133 verbose node v14.16.0
134 verbose npm  v7.17.0
135 error code 1
136 error path /home/vincent/code/prose-language-server/node_modules/tree-sitter-markdown
137 error command failed
138 error command sh -c node-gyp rebuild
139 error make: Entering directory '/home/vincent/code/prose-language-server/node_modules/tree-sitter-markdown/build'
139 error   CC(target) Release/obj.target/tree_sitter_markdown_binding/src/parser.o
139 error   CXX(target) Release/obj.target/tree_sitter_markdown_binding/bindings/node/binding.o
139 error   CXX(target) Release/obj.target/tree_sitter_markdown_binding/src/scanner.o
139 error make: Leaving directory '/home/vincent/code/prose-language-server/node_modules/tree-sitter-markdown/build'
140 error gyp info it worked if it ends with ok
140 error gyp info using node-gyp@8.1.0
140 error gyp info using node@14.16.0 | linux | x64
140 error gyp info find Python using Python version 3.9.6 found at "/usr/bin/python3"
140 error gyp info spawn /usr/bin/python3
140 error gyp info spawn args [
140 error gyp info spawn args   '/usr/lib/node_modules/node-gyp/gyp/gyp_main.py',
140 error gyp info spawn args   'binding.gyp',
140 error gyp info spawn args   '-f',
140 error gyp info spawn args   'make',
140 error gyp info spawn args   '-I',
140 error gyp info spawn args   '/home/vincent/code/prose-language-server/node_modules/tree-sitter-markdown/build/config.gypi',
140 error gyp info spawn args   '-I',
140 error gyp info spawn args   '/usr/lib/node_modules/node-gyp/addon.gypi',
140 error gyp info spawn args   '-I',
140 error gyp info spawn args   '/home/vincent/.cache/node-gyp/14.16.0/include/node/common.gypi',
140 error gyp info spawn args   '-Dlibrary=shared_library',
140 error gyp info spawn args   '-Dvisibility=default',
140 error gyp info spawn args   '-Dnode_root_dir=/home/vincent/.cache/node-gyp/14.16.0',
140 error gyp info spawn args   '-Dnode_gyp_dir=/usr/lib/node_modules/node-gyp',
140 error gyp info spawn args   '-Dnode_lib_file=/home/vincent/.cache/node-gyp/14.16.0/<(target_arch)/node.lib',
140 error gyp info spawn args   '-Dmodule_root_dir=/home/vincent/code/prose-language-server/node_modules/tree-sitter-markdown',
140 error gyp info spawn args   '-Dnode_engine=v8',
140 error gyp info spawn args   '--depth=.',
140 error gyp info spawn args   '--no-parallel',
140 error gyp info spawn args   '--generator-output',
140 error gyp info spawn args   'build',
140 error gyp info spawn args   '-Goutput_dir=.'
140 error gyp info spawn args ]
140 error gyp info spawn make
140 error gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
140 error In file included from ../src/parser.c:1:
140 error ../src/parser.c: In function ‘ts_lex’:
140 error ../src/tree_sitter/parser.h:136:11: warning: variable ‘lookahead’ set but not used [-Wunused-but-set-variable]
140 error   136 |   int32_t lookahead;            \
140 error       |           ^~~~~~~~~
140 error ../src/parser.c:1756:3: note: in expansion of macro ‘START_LEXER’
140 error  1756 |   START_LEXER();
140 error       |   ^~~~~~~~~~~
140 error In file included from ../bindings/node/binding.cc:2:
140 error /home/vincent/.cache/node-gyp/14.16.0/include/node/node.h:758:7: warning: cast between incompatible function types from ‘void (*)(v8::Local<v8::Object>, v8::Local<v8::Object>)’ to ‘node::addon_register_func’ {aka ‘void (*)(v8::Local<v8::Object>, v8::Local<v8::Value>, void*)’} [-Wcast-function-type]
140 error   758 |       (node::addon_register_func) (regfunc),                          \
140 error       |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
140 error /home/vincent/.cache/node-gyp/14.16.0/include/node/node.h:792:3: note: in expansion of macro ‘NODE_MODULE_X’
140 error   792 |   NODE_MODULE_X(modname, regfunc, NULL, 0)  // NOLINT (readability/null_usage)
140 error       |   ^~~~~~~~~~~~~
140 error ../bindings/node/binding.cc:26:1: note: in expansion of macro ‘NODE_MODULE’
140 error    26 | NODE_MODULE(tree_sitter_markdown_binding, Init)
140 error       | ^~~~~~~~~~~
140 error ../src/./tree_sitter_markdown/block_context.cc: In member function ‘tree_sitter_markdown::ParseState tree_sitter_markdown::BlockContext::pst() const’:
140 error ../src/scanner.cc:9:72: error: exception handling disabled, use ‘-fexceptions’ to enable
140 error     9 | #define TREE_SITTER_MARKDOWN_ASSERT(condition) if (!(condition)) throw 1;
140 error       |                                                                        ^
140 error ../src/./tree_sitter_markdown/block_context.cc:9:40: note: in expansion of macro ‘TREE_SITTER_MARKDOWN_ASSERT’
140 error     9 | ParseState BlockContext::pst() const { TREE_SITTER_MARKDOWN_ASSERT(pst_ != PST_INVALID); return pst_; }
140 error       |                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
140 error In file included from ../src/scanner.cc:23:
140 error ../src/./tree_sitter_markdown/lexer.cc: In member function ‘void tree_sitter_markdown::Lexer::adv(bool)’:
140 error ../src/./tree_sitter_markdown/lexer.cc:106:37: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<int>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
140 error   106 |     if (cur_idx_ - buf_bgn_idx_ + 1 >= chr_buf_.size()) {
140 error       |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
140 error ../src/./tree_sitter_markdown/lexer.cc: In member function ‘void tree_sitter_markdown::Lexer::jmp_pos(const tree_sitter_markdown::LexedPosition&)’:
140 error ../src/./tree_sitter_markdown/lexer.cc:174:56: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<int>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
140 error   174 |   TREE_SITTER_MARKDOWN_ASSERT(pos.idx() - buf_bgn_idx_ < chr_buf_.size() - 1);
140 error       |                               ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
140 error ../src/scanner.cc:9:54: note: in definition of macro ‘TREE_SITTER_MARKDOWN_ASSERT’
140 error     9 | #define TREE_SITTER_MARKDOWN_ASSERT(condition) if (!(condition)) throw 1;
140 error       |                                                      ^~~~~~~~~
140 error ../src/./tree_sitter_markdown/lexer.cc: In member function ‘bool tree_sitter_markdown::Lexer::has_chr_at_idx(tree_sitter_markdown::LexedCharacter, tree_sitter_markdown::LexedIndex) const’:
140 error ../src/./tree_sitter_markdown/lexer.cc:185:50: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<int>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
140 error   185 |   TREE_SITTER_MARKDOWN_ASSERT(idx - buf_bgn_idx_ < chr_buf_.size());
140 error       |                               ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
140 error ../src/scanner.cc:9:54: note: in definition of macro ‘TREE_SITTER_MARKDOWN_ASSERT’
140 error     9 | #define TREE_SITTER_MARKDOWN_ASSERT(condition) if (!(condition)) throw 1;
140 error       |                                                      ^~~~~~~~~
140 error In file included from ../src/scanner.cc:23:
140 error ../src/./tree_sitter_markdown/lexer.cc:186:14: warning: comparison is always false due to limited range of data type [-Wtype-limits]
140 error   186 |   return idx < 0 ? false : chr_buf_[idx - buf_bgn_idx_] == chr;
140 error       |          ~~~~^~~
140 error ../src/./tree_sitter_markdown/lexer.cc: In member function ‘bool tree_sitter_markdown::Lexer::has_chr_at_idx(bool (*)(tree_sitter_markdown::LexedCharacter), tree_sitter_markdown::LexedIndex) const’:
140 error ../src/./tree_sitter_markdown/lexer.cc:190:50: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<int>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
140 error   190 |   TREE_SITTER_MARKDOWN_ASSERT(idx - buf_bgn_idx_ < chr_buf_.size());
140 error       |                               ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
140 error ../src/scanner.cc:9:54: note: in definition of macro ‘TREE_SITTER_MARKDOWN_ASSERT’
140 error     9 | #define TREE_SITTER_MARKDOWN_ASSERT(condition) if (!(condition)) throw 1;
140 error       |                                                      ^~~~~~~~~
140 error In file included from ../src/scanner.cc:23:
140 error ../src/./tree_sitter_markdown/lexer.cc:191:14: warning: comparison is always false due to limited range of data type [-Wtype-limits]
140 error   191 |   return idx < 0 ? false : is_chr(chr_buf_[idx - buf_bgn_idx_]);
140 error       |          ~~~~^~~
140 error ../src/./tree_sitter_markdown/lexer.cc: In member function ‘bool tree_sitter_markdown::Lexer::has_chr_in_rng(bool (*)(tree_sitter_markdown::LexedCharacter), tree_sitter_markdown::LexedIndex, tree_sitter_markdown::LexedIndex) const’:
140 error ../src/./tree_sitter_markdown/lexer.cc:196:54: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<int>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
140 error   196 |   TREE_SITTER_MARKDOWN_ASSERT(end_idx - buf_bgn_idx_ < chr_buf_.size() - 1);
140 error       |                               ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
140 error ../src/scanner.cc:9:54: note: in definition of macro ‘TREE_SITTER_MARKDOWN_ASSERT’
140 error     9 | #define TREE_SITTER_MARKDOWN_ASSERT(condition) if (!(condition)) throw 1;
140 error       |                                                      ^~~~~~~~~
140 error In file included from ../src/scanner.cc:21:
140 error ../src/./tree_sitter_markdown/inline_scan.cc: In function ‘bool tree_sitter_markdown::scn_blk_txt(tree_sitter_markdown::Lexer&, tree_sitter_markdown::InlineDelimiterList&, tree_sitter_markdown::InlineContextStack&, tree_sitter_markdown::BlockDelimiterList&, tree_sitter_markdown::BlockContextStack&)’:
140 error ../src/./tree_sitter_markdown/inline_scan.cc:307:1: warning: control reaches end of non-void function [-Wreturn-type]
140 error   307 | }
140 error       | ^
140 error In file included from ../src/scanner.cc:23:
140 error ../src/./tree_sitter_markdown/lexer.cc: In member function ‘tree_sitter_markdown::LexedLength tree_sitter_markdown::Lexer::clc_vtr_spc_cnt(tree_sitter_markdown::LexedColumn, tree_sitter_markdown::LexedColumn, tree_sitter_markdown::LexedLength&) const’:
140 error ../src/./tree_sitter_markdown/lexer.cc:242:1: warning: control reaches end of non-void function [-Wreturn-type]
140 error   242 | }
140 error       | ^
140 error In file included from ../src/scanner.cc:24:
140 error ../src/./tree_sitter_markdown/parse_table.cc: In function ‘tree_sitter_markdown::Symbol tree_sitter_markdown::get_blk_cls_sym(tree_sitter_markdown::Symbol)’:
140 error ../src/./tree_sitter_markdown/parse_table.cc:50:5: warning: control reaches end of non-void function [-Wreturn-type]
140 error    50 |     default: TREE_SITTER_MARKDOWN_ASSERT(false);
140 error       |     ^~~~~~~
140 error make: *** [tree_sitter_markdown_binding.target.mk:117: Release/obj.target/tree_sitter_markdown_binding/src/scanner.o] Error 1
140 error gyp ERR! build error
140 error gyp ERR! stack Error: `make` failed with exit code: 2
140 error gyp ERR! stack     at ChildProcess.onExit (/usr/lib/node_modules/node-gyp/lib/build.js:194:23)
140 error gyp ERR! stack     at ChildProcess.emit (events.js:315:20)
140 error gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:277:12)
140 error gyp ERR! System Linux 5.12.15-arch1-1
140 error gyp ERR! command "/usr/bin/node" "/usr/lib/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
140 error gyp ERR! cwd /home/vincent/code/prose-language-server/node_modules/tree-sitter-markdown
140 error gyp ERR! node -v v14.16.0
140 error gyp ERR! node-gyp -v v8.1.0
140 error gyp ERR! not ok
141 verbose exit 1

```

</details>

I managed to make it work by adding the `cflags_cc -fexceptions` flag. 