### PR TITLE
Fix crash when seeing 256 '['s

### DIFF
--- a/src/tree_sitter_markdown/block_context.cc
+++ b/src/tree_sitter_markdown/block_context.cc
@@ -72,6 +72,7 @@ unsigned BlockContextStack::deserialize(const unsigned char *buffer) {
 }
 
 void BlockContextStack::push(const BlockContext &ctx) {
+  TREE_SITTER_MARKDOWN_ASSERT(stk_.size() < 255);
   stk_.push_back(ctx);
 }
 void BlockContextStack::pop() {

--- a/src/tree_sitter_markdown/block_delimiter.cc
+++ b/src/tree_sitter_markdown/block_delimiter.cc
@@ -140,7 +140,7 @@ void BlockDelimiterList::drop_pos() {
 unsigned BlockDelimiterList::serialize(unsigned char *buffer) const {
   size_t i = 0;
   size_t size_i = i++;
-  size_t size = 0;
+  unsigned char size = 0;
   for (ConstIterator itr = list_.begin(), end = list_.end(); itr != end; itr++) {
     i += itr->serialize(&buffer[i]);
     size++;
@@ -160,6 +160,7 @@ unsigned BlockDelimiterList::deserialize(const unsigned char *buffer) {
 void BlockDelimiterList::pop_front() { list_.pop_front(); }
 void BlockDelimiterList::push_back(const BlockDelimiter &dlm) { list_.push_back(dlm); }
 BlockDelimiterList::Iterator BlockDelimiterList::insert(const BlockDelimiterList::Iterator itr, const BlockDelimiter &dlm) {
+  TREE_SITTER_MARKDOWN_ASSERT(list_.size() < 255);
   return list_.insert(itr, dlm);
 }
 BlockDelimiterList::Iterator BlockDelimiterList::insert(const LexedRow row, const BlockDelimiter &dlm) {

--- a/src/tree_sitter_markdown/inline_delimiter.cc
+++ b/src/tree_sitter_markdown/inline_delimiter.cc
@@ -170,13 +170,16 @@ bool MinimizedInlineDelimiterList::empty() const { return list_.empty(); }
 MinimizedInlineDelimiter &MinimizedInlineDelimiterList::front() { return list_.front(); }
 
 void MinimizedInlineDelimiterList::pop_front() { list_.pop_front(); }
-void MinimizedInlineDelimiterList::push_back(const MinimizedInlineDelimiter &delimiter) { list_.push_back(delimiter); }
+void MinimizedInlineDelimiterList::push_back(const MinimizedInlineDelimiter &delimiter) {
+    TREE_SITTER_MARKDOWN_ASSERT(list_.size() < 255);
+    list_.push_back(delimiter);
+}
 
 void MinimizedInlineDelimiterList::clear() { list_.clear(); }
 unsigned MinimizedInlineDelimiterList::serialize(unsigned char *buffer) const {
   size_t i = 0;
   size_t size_i = i++;
-  size_t size = 0;
+  unsigned char size = 0;
   for (ConstIterator itr = list_.begin(), end = list_.end(); itr != end; itr++) {
     i += itr->serialize(&buffer[i]);
     size++;


### PR DESCRIPTION
Addresses, though perhaps doesn't exactly fix, the crash reported in #32.

If a `MinimizedInlineDelimiterList` contains 256 or more elements, the `char`-sized `size` wraps in serialization. This causes the subsequent failure at deserialization.

I've added an assertion to say that this list shouldn't be too long.  This improves things because the new assertion now happens during scanning, where the try-except can kick in - and not in deserialization, where it couldn't.

Probably there's some more graceful way of handling this, but that's beyond me for now...

I added similar assertions in the `BlockContextStack` and `BlockDelimiterList`: these look as though they have the same error.