### PR TITLE
Update binding.gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -15,6 +15,8 @@
         "-std=c99",
         "-fexceptions"
       ],
+      'cflags!': [ '-fno-exceptions' ],
+      'cflags_cc!': [ '-fno-exceptions' ],
       "defines": [
         "TREE_SITTER_MARKDOWN_AVOID_CRASH"
       ],


### PR DESCRIPTION
Node 14.17.5, pnpm 6.14.3, both installed via Nix 2.3.15 on Ubuntu 20.04: `node-gyp` fails, returning a big pile of warnings, plus this one error:
```
│ ../src/./tree_sitter_markdown/block_context.cc: In member function ‘tree_sitter_markdown::ParseState tree_sitter_markdown::Bloc                                                                                                                                      
│ ../src/scanner.cc:9:72: error: exception handling disabled, use ‘-fexceptions’ to enable                                                                                                                                                                             
│     9 | #define TREE_SITTER_MARKDOWN_ASSERT(condition) if (!(condition)) throw 1;   
```

With the attached fix, the build succeeds and `tree-sitter-markdown` seems to work normally so far.

Based on info from https://github.com/nodejs/node-gyp/issues/17