### PR TITLE
fix oom

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -228,11 +228,6 @@ struct Scanner {
 
       has_opt_wsp_ind_ = false;
 
-      if (is_eol_chr(lxr_.lka_chr()) && !has_txt) {
-        lxr_.mrk_end();
-        return lxr_.ret_sym(TKN_WSP);
-      }
-
       TREE_SITTER_MARKDOWN_ASSERT(has_txt);
       if (!is_wsp_chr(lxr_.cur_chr())) lxr_.mrk_end();
       return lxr_.ret_sym(valid_symbols[TKN_WRD] ? TKN_WRD : TKN_TXT);


### PR DESCRIPTION
This addresses - but does not exactly fix - the out-of-memory reported in #32.

I have removed a block of code which, I suppose, is somehow mis-handling this case.  This isn't a clean fix, we now go on to hit the assertion that follows: but with `TREE_SITTER_MARKDOWN_AVOID_CRASH` we catch this error and seem to recover.

The input:
```markdown
[foo](*https://example.com
[foo](*https://example.com
```
now parses as:
```
(document [0, 0] - [1, 26]
  (paragraph [0, 0] - [1, 26]
    (link [0, 0] - [0, 5]
      (link_text [0, 1] - [0, 4]
        (text [0, 1] - [0, 4])))
    (text [0, 5] - [0, 7])
    (uri_autolink [0, 7] - [0, 26]
      (text [0, 7] - [0, 26]))
    (soft_line_break [0, 26] - [1, 0])
    (link [1, 0] - [1, 5]
      (link_text [1, 1] - [1, 4]
        (text [1, 1] - [1, 4])))
    (text [1, 5] - [1, 7])
    (uri_autolink [1, 7] - [1, 26]
      (text [1, 7] - [1, 26]))))
```
I was expecting an error!  But this doesn't look stupid, and certainly is a lot better than looping and consuming all available RAM.